### PR TITLE
Add logged conditional sampling during validation

### DIFF
--- a/llama_recipes/configs/training.py
+++ b/llama_recipes/configs/training.py
@@ -35,6 +35,7 @@ class train_config:
     data_path: str = None
     num_validation_samples: int = 100
     validation_data_path: str = None
+    validation_prompt: str = None
 
     
     


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/replicate/cog-llama-template/issues/15) and makes the following contributions:

* expose a ` validation_prompt` field in the training API
* add a conditional token sampling and decoding step to the validation process
* log the decoded tokens

This allows users to specify a prompt at train time that will then be use to conditionally sample tokens during validation. This gives them insight into how their model changes qualitatively over time. 