### PR TITLE
Add support for lora target modules

### DIFF
--- a/llama_recipes/configs/peft.py
+++ b/llama_recipes/configs/peft.py
@@ -9,7 +9,7 @@ import torch
 class lora_config:
      r: int=8
      lora_alpha: int=16
-     target_modules: ClassVar[List[str]]= ["q_proj", "v_proj"]
+     target_modules: List[str] = field(default_factory=lambda: ["q_proj", "v_proj"])
      bias= "none"
      task_type: str= "CAUSAL_LM"
      lora_dropout: float=0.05

--- a/llama_recipes/configs/training.py
+++ b/llama_recipes/configs/training.py
@@ -39,6 +39,7 @@ class train_config:
     wrap_packed_sequences: bool = False
     pack_sequences: bool = True
     chunk_size: int = 2048
+    target_modules: str = "q_proj,v_proj"
 
 
     

--- a/llama_recipes/llama_finetuning.py
+++ b/llama_recipes/llama_finetuning.py
@@ -204,10 +204,13 @@ def main(**kwargs):
     
     else:
         kwargs['r'] = kwargs['lora_rank'] # can't pass --r to the script, torchrun won't have it
+        kwargs['target_modules'] = list(train_config.target_modules)
         peft_config = generate_peft_config(train_config.peft_method, kwargs)
+        if rank == 0:
+            print(f"PEFT CONFIG: {peft_config}")
 
-        # Model preparation for QLoRA fine-tuning ------
-        # ----------------------------------------------
+    #     # Model preparation for QLoRA fine-tuning ------
+    #     # ----------------------------------------------
         if train_config.peft_method == 'qlora':
             print('LOADING MODEL FOR QLORA')
             bnb_config = generate_peft_config('bitsandbytes_config', kwargs)

--- a/llama_recipes/utils/config_utils.py
+++ b/llama_recipes/utils/config_utils.py
@@ -2,7 +2,7 @@
 # This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
 
 import inspect
-from dataclasses import fields
+from dataclasses import fields, asdict
 from peft import (
     LoraConfig,
     AdaptionPromptConfig,
@@ -62,11 +62,16 @@ def generate_peft_config(peft_method, kwargs):
 
     # Step 3: Fetch the correct configuration class based on train_config.peft_method
     config = config_mapping[peft_method]
-    update_config(config, **kwargs)
-    params = {k.name: getattr(config, k.name) for k in fields(config)}
+    config_instance = config()
+
+    update_config(config_instance, **kwargs)
 
     # Step 5: Fetch the correct PEFT config based on the configuration class
     peft_config_class = peft_config_mapping[config]
+
+    # params = {k.name: getattr(config, k.name) for k in fields(config)}
+    params = asdict(config_instance)
+
     peft_config = peft_config_class(**params)
 
     return peft_config                

--- a/train.py
+++ b/train.py
@@ -25,7 +25,7 @@ from config import (
     REMOTE_TRAINING_WEIGHTS_CONFIG_PATH,
     REMOTE_TRAINING_FILES_TO_DOWNLOAD,
     MODEL_NAME,
-    log_memory_stuff
+    # log_memory_stuff
 )
 
 from src.utils import maybe_download_with_pget, download_file_with_pget
@@ -131,7 +131,7 @@ def train(
         description="Rank of the lora matrices", default=8, ge=1),
     lora_alpha: int = Input(description="Alpha parameter for scaling lora weights; weights are scaled by alpha/rank", default=16, ge=1),
     lora_dropout: float = Input(description="Dropout for lora training", default=0.05, ge=0.0, le=1.0),
-    # lora_target_modules: str = Input(description="Comma-separated list of lora modules to target, i.e. 'q_proj,v_proj'. Leave blank for default.", default="q_proj,v_proj")
+    lora_target_modules: str = Input(description="Comma-separated list of lora modules to target, i.e. 'q_proj,v_proj'. Leave blank for default.", default="q_proj,v_proj")
 ) -> TrainingOutput:
     if fake_output:
         out_path = f"/tmp/{os.path.basename(fake_output)}"
@@ -209,6 +209,7 @@ def train(
         f"--lora_alpha={lora_alpha}",
         f"--lora_dropout={lora_dropout}",
         f"--peft_method={peft_method}",
+        f"--target_modules={lora_target_modules}",
         # Validation arguments
         f"--run_validation={'False' if not run_validation else 'True'}",
         f"--num_validation_samples={num_validation_samples}",


### PR DESCRIPTION
This PR adds a train parameter `lora_target_modules` that allows users to configure target modules via the API. The default target modules remain consistent with the target modules we've been using. However, we do not currently restrict target modules in any sense, so it is up to the user to specify correct module names as well as anticipate whether or not their inference engine is compatible with the target modules they've specified. 

As such, this feature does not provide any safety or support for users and it is expected that they know what they're doing. Future implementations should probably build in some safety rails for users, but for now I think this is sufficient for experimentation. 