### PR TITLE
use python downloader instead of pget

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,1 +1,1 @@
-models/llama-2-7b-vllm/config.py
+models/llama-2-7b-mlc/config.py

--- a/src/download.py
+++ b/src/download.py
@@ -137,7 +137,7 @@ class Downloader:
         buf.seek(0)
         print(
             f"Downloaded {os.path.basename(str(url))} as {concurrency} {chunk_size // 1024}"
-            f" kB chunks in {time.time() - start_time:.4f} with {self.retries} retries"
+            f" kB chunks in {time.time() - start_time:.3f}s with {self.retries} retries"
         )
         self.retries = 0
         return buf

--- a/src/download.py
+++ b/src/download.py
@@ -16,7 +16,7 @@ from .utils import check_files_exist
 # 1. os.sched_getaffinity to work right in docker
 # 2. memoryview for less copies
 # 3. keep redirects from the first head
-MIN_CHUNK_SIZE = 1024 * 32  # 32kb
+MIN_CHUNK_SIZE = 1024 * 1024 * 16 # 16mb
 
 global_downloader = None
 

--- a/src/download.py
+++ b/src/download.py
@@ -1,27 +1,39 @@
 import asyncio
 import io
+import functools
 import os
 import random
-import time
+import shutil
 import sys
+import time
+import typing as t
+from concurrent.futures import ThreadPoolExecutor
 import aiohttp
 from yarl import URL
+from .utils import check_files_exist
 
 # some important tricks:
 # 1. os.sched_getaffinity to work right in docker
 # 2. memoryview for less copies
 # 3. keep redirects from the first head
+MIN_CHUNK_SIZE = 1024 * 32  # 32kb
+
+global_downloader = None
+
 
 class Downloader:
     def __init__(self, concurrency: int | None = None) -> None:
         if not concurrency:
             concurrency = len(os.sched_getaffinity(0))
         self.concurrency = concurrency
+        self.sem = asyncio.Semaphore(concurrency * 2)
         self.retries = 0
         try:
             self.loop = asyncio.get_running_loop()
         except RuntimeError:
             self.loop = asyncio.new_event_loop()
+        global global_downloader
+        global_downloader = self
 
     _session: aiohttp.ClientSession | None = None
 
@@ -33,6 +45,14 @@ class Downloader:
                 loop=self.loop,
             )
         return self._session
+
+    _threadpool: ThreadPoolExecutor | None
+
+    @property
+    def threadpool(self) -> ThreadPoolExecutor:
+        if not self._threadpool:
+            self._threadpool = ThreadPoolExecutor(2)
+        return self._threadpool
 
     async def get_remote_file_size(self, url: str | URL) -> "tuple[URL, int]":
         try:
@@ -71,29 +91,25 @@ class Downloader:
     async def download_chunk(
         self, url: str | URL, start: int, end: int, buffer_view: memoryview
     ) -> None:
-        for i in range(5):
-            headers = {"Retry-Count": str(i)} if i else {}
-            try:
-                headers |= {"Range": f"bytes={start}-{end}"}
-                async with self.session.get(url, headers=headers) as response:
-                    buffer_view[start : end + 1] = await response.read()
-                    return
-            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
-                print(f"Error: {e}")
-                await asyncio.sleep(random.random() / 10)  # sleep 0-100ms
+        async with self.sem:
+            for i in range(5):
+                headers = {"Retry-Count": str(i)} if i else {}
+                try:
+                    headers |= {"Range": f"bytes={start}-{end}"}
+                    async with self.session.get(url, headers=headers) as response:
+                        buffer_view[start : end + 1] = await response.read()
+                        return
+                except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                    print(f"Error: {e}")
+                    await asyncio.sleep(random.random() / 10)  # sleep 0-100ms
         raise ValueError(f"Failed to download {url} after multiple retries")
 
     async def download_file(self, url: str | URL) -> io.BytesIO:
         self.retries = 0
         start_time = time.time()
         url, file_size = await self.get_remote_file_size(url)
+        concurrency = min((file_size // MIN_CHUNK_SIZE or 1), self.concurrency)
         chunk_size = file_size // self.concurrency
-        # if it's less than 1kB, download only as a single chunk
-        if chunk_size < 1 << 10:
-            concurrency = 1
-            chunk_size = file_size
-        else:
-            concurrency = self.concurrency
         tasks = []
         buf = io.BytesIO()
         buf.write(b"\0" * file_size)
@@ -113,16 +129,48 @@ class Downloader:
         self.retries = 0
         return buf
 
-    def sync_download_file(self, url: str) -> io.BytesIO:
-        try:
-            return self.loop.run_until_complete(self.download_file(url))
-        except RuntimeError as e:
-            if e.args[0] == "Event loop is closed":
-                print("has to start a new event loop")
-                self.loop = asyncio.new_event_loop()
-                self._session = None
-                return self.loop.run_until_complete(self.download_file(url))
-            raise e
+    async def download_file_to_disk(self, url: str, path: str) -> None:
+        buf = await self.download_file(url)
+        # don't block the event loop for disk io
+        await self.loop.run_in_executor(
+            self.threadpool,
+            lambda: shutil.copyfileobj(buf, open(path, "wb"), length=2 << 18),
+        )
+
+    async def maybe_download_files_to_disk(
+        self, path: str, remote_path: str, filenames: list[str]
+    ) -> None:
+        remote_path = remote_path.rstrip("/")
+        if not os.path.exists(path):
+            os.makedirs(path, exist_ok=True)
+            missing_files = filenames
+        else:
+            missing_files = check_files_exist(filenames, path)
+        coros = [
+            self.download_file_to_disk(f"{remote_path}/{f}", f"{path}/{f}")
+            for f in missing_files
+        ]
+        await asyncio.gather(*coros)
+
+    def sync(f: t.Callable) -> t.Callable:
+        # pylint: disable=no-self-argument
+        @functools.wraps(f)
+        def wrapper(self: "Downloader", *args: t.Any, **kwargs: t.Any) -> t.Any:
+            try:
+                return self.loop.run_until_complete(f(self, *args, **kwargs))
+            except RuntimeError as e:
+                if e.args[0] == "Event loop is closed":
+                    print("has to start a new event loop")
+                    self.loop = asyncio.new_event_loop()
+                    self._session = None
+                    return self.loop.run_until_complete(f(self, *args, **kwargs))
+                raise e
+
+        return wrapper
+
+    sync_download_file = sync(download_file)
+    sync_maybe_download_files = sync(maybe_download_files_to_disk)
+
 
 if __name__ == "__main__":
     Downloader().sync_download_file(sys.argv[1])

--- a/src/inference_engines/engine.py
+++ b/src/inference_engines/engine.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from src.config_utils import Weights
+from src import download
 from src.utils import maybe_download_with_pget
 
 
@@ -11,7 +12,8 @@ class Engine(ABC):
     """
 
     def load_weights(self, weights: Weights):
-        maybe_download_with_pget(weights.local_path, weights.remote_path, weights.remote_files)
+        downloader = download.global_downloader or download.Downloader()
+        downloader.sync_maybe_download_files(weights.local_path, weights.remote_path, weights.remote_files)
         return weights.local_path
 
 

--- a/src/inference_engines/engine.py
+++ b/src/inference_engines/engine.py
@@ -16,7 +16,7 @@ class Engine(ABC):
         downloader = download.global_downloader or download.Downloader()
         start = time.time()
         downloader.sync_maybe_download_files(weights.local_path, weights.remote_path, weights.remote_files)
-        print(f"downloading weights took {time.time() - start:.3f}")
+        print(f"downloading weights took {time.time() - start:.3f}s")
         return weights.local_path
 
 

--- a/src/inference_engines/engine.py
+++ b/src/inference_engines/engine.py
@@ -1,3 +1,4 @@
+import time
 from abc import ABC, abstractmethod
 from typing import Any
 
@@ -13,7 +14,9 @@ class Engine(ABC):
 
     def load_weights(self, weights: Weights):
         downloader = download.global_downloader or download.Downloader()
+        start = time.time()
         downloader.sync_maybe_download_files(weights.local_path, weights.remote_path, weights.remote_files)
+        print(f"downloading weights took {time.time() - start:.3f}")
         return weights.local_path
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,17 +4,16 @@ import random
 import time
 import typing as tp
 import asyncio
-import torch
 
 def seed_all(seed: int):
+    import numpy
+    import torch
+
     os.environ["PYTHONHASHSEED"] = str(seed)
     torch.manual_seed(seed)
     torch.cuda.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)
     random.seed(seed)
-
-    import numpy
-
     numpy.random.seed(seed)
 
 
@@ -74,7 +73,7 @@ def check_files_exist(remote_files, local_path):
     local_files = os.listdir(local_path)
 
     # Check if each remote file exists in the local directory
-    missing_files = [file for file in remote_files if file not in local_files]
+    missing_files = list(set(remote_files) - set(local_files))
 
     return missing_files
 
@@ -152,7 +151,6 @@ def maybe_download_with_pget(
             os.makedirs(path, exist_ok=True)
             missing_files = remote_filenames
         else:
-            local_files = os.listdir(path)
             missing_files = check_files_exist(remote_filenames, path)
 
         if len(missing_files) > 0:

--- a/src/utils.py
+++ b/src/utils.py
@@ -68,7 +68,7 @@ def download_file(file, local_filename):
     return
 
 
-def check_files_exist(remote_files, local_path):
+def check_files_exist(remote_files: list[str], local_path: str) -> list[str]:
     # Get the list of local file names
     local_files = os.listdir(local_path)
 


### PR DESCRIPTION
this will reuse connections across downloaded files, which can't be done with current versions of pget. it uses a semaphore to limit the number of connections across all files without explicit batching or changing concurrency based on number or files