### PR TITLE
delay prints with a decorator

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -82,7 +82,11 @@ class Predictor(BasePredictor):
         self.current_path = None
         self.engine.delete_lora()
 
-    @delay_prints()
+    # currently, outputs including tokens and logs are throttled to 50ms
+    # because of this, printing before outputing tokens is bad
+    # so this patches print to not only print until after we leave this function
+    # eventually that will be fixed and this can be removed
+    @delay_prints(REALLY_EAT_MY_PRINT_STATEMENTS=True)
     def predict(
         self,
         prompt: str = Input(description="Prompt to send to the model."),

--- a/predict.py
+++ b/predict.py
@@ -11,7 +11,7 @@ from cog import BasePredictor, ConcatenateIterator, Input, Path
 
 from config import ENGINE, ENGINE_KWARGS, USE_SYSTEM_PROMPT
 from src.download import Downloader
-from src.utils import seed_all
+from src.utils import seed_all, delay_prints
 
 # This prompt formatting was copied from the original Llama v2 repo:
 # https://github.com/facebookresearch/llama/blob/6c7fe276574e78057f917549435a2554000a876d/llama/generation.py#L44
@@ -82,6 +82,7 @@ class Predictor(BasePredictor):
         self.current_path = None
         self.engine.delete_lora()
 
+    @delay_prints()
     def predict(
         self,
         prompt: str = Input(description="Prompt to send to the model."),

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,9 +1,12 @@
 import asyncio
+import builtins
+import contextlib
 import os
 import random
 import subprocess
 import time
 import typing as tp
+
 
 def seed_all(seed: int):
     import numpy
@@ -59,6 +62,7 @@ def get_loop() -> asyncio.AbstractEventLoop:
         return asyncio.get_running_loop()
     except RuntimeError:
         return asyncio.new_event_loop()
+
 
 def download_file(file, local_filename):
     print(f"Downloading {file} to {local_filename}")
@@ -281,3 +285,19 @@ class StreamingTextStopSequenceHandler:
         if self.cache:
             yield from self.cache
             self.cache.clear()
+
+
+@contextlib.contextmanager
+def delay_prints() -> tp.Iterator[None]:
+    lines = []
+
+    def delayed_print(*args: tp.Any, **kwargs: tp.Any) -> None:
+        lines.append((args, kwargs))
+
+    builtins.print, _print = delayed_print, builtins.print
+    try:
+        yield
+    finally:
+        builtins.print = _print
+        for args, kwargs in lines:
+            print(*args, **kwargs)

--- a/src/utils.py
+++ b/src/utils.py
@@ -287,22 +287,21 @@ class StreamingTextStopSequenceHandler:
             self.cache.clear()
 
 
-def delay_prints(REALLY_EAT_MY_PRINT_STATEMENTS: bool) -> tp.Callable:
-    if not REALLY_EAT_MY_PRINT_STATEMENTS:
-        return lambda f: f
-
+def delay_prints(REALLY_EAT_MY_PRINT_STATEMENTS: bool = False) -> tp.Callable:
     @contextlib.contextmanager
-    def _delay_prints() -> tp.Iterator[None]:
+    def _delay_prints() -> tp.Iterator[tp.Callable]:
         lines = []
 
         def delayed_print(*args: tp.Any, **kwargs: tp.Any) -> None:
             lines.append((args, kwargs))
 
-        builtins.print, _print = delayed_print, builtins.print
+        if REALLY_EAT_MY_PRINT_STATEMENTS:
+            builtins.print, _print = delayed_print, builtins.print
         try:
-            yield
+            yield delayed_print
         finally:
-            builtins.print = _print
+            if REALLY_EAT_MY_PRINT_STATEMENTS:
+                builtins.print = _print
             for args, kwargs in lines:
                 print(*args, **kwargs)
 


### PR DESCRIPTION
cog throttles output to send webhooks at most once every 50ms, and prints count as output, so we don't want to print before yielding the first token. this is a relatively unobstructive way to do that that ensures we can still see any debugging information if there are errors 