### PR TITLE
properly decode emoji

### DIFF
--- a/src/inference_engines/mlc_engine.py
+++ b/src/inference_engines/mlc_engine.py
@@ -173,7 +173,7 @@ class MLCEngine(Engine):
             self.cm._decode(generation_config=generation_config)
             out = self.cm._get_message()
             # stops us from yielding half an emoji, which breaks
-            out = out.replace("�", "") 
+            out = out.replace("\N{Replacement Character}", "") 
             if len(out) == generation_length:
                 # don't yield an empty string
                 continue

--- a/src/inference_engines/mlc_engine.py
+++ b/src/inference_engines/mlc_engine.py
@@ -172,5 +172,10 @@ class MLCEngine(Engine):
                 break
             self.cm._decode(generation_config=generation_config)
             out = self.cm._get_message()
+            # stops us from yielding half an emoji, which breaks
+            out = out.replace("�", "") 
+            if len(out) == generation_length:
+                # don't yield an empty string
+                continue
             yield out[generation_length:]
             generation_length = len(out)

--- a/src/inference_engines/vllm_engine.py
+++ b/src/inference_engines/vllm_engine.py
@@ -227,7 +227,10 @@ class vLLMEngine(Engine):
                 assert len(request_output.outputs) == 1
                 generated_text = request_output.outputs[0].text
                 if incremental_generation:
-                    yield generated_text[generation_length:]
+                    # it takes multiple calls to gen.__anext__ to render one emoji. 
+                    # this check keeps us from needlesly yielding empty strings
+                    if len(generated_text) > generation_length:
+                        yield generated_text[generation_length:]
                 else:
                     yield generated_text
                 generation_length = len(generated_text)

--- a/src/inference_engines/vllm_exllama_engine.py
+++ b/src/inference_engines/vllm_exllama_engine.py
@@ -74,6 +74,8 @@ class ExllamaVllmEngine(Engine):
         stop_sequences: Optional[List[str]] = None,
         **kwargs,
     ):
+        if top_k <=0:
+            top_k = 50
         print(f"Exllama: {isinstance(self.engine, ExllamaEngine)}")
         gen = self.engine(
             prompt,


### PR DESCRIPTION
Unlike words, emoji aren't simply the concatenation of their decoded tokens. The individual tokens that make up an emoji are decoded as �, so if we stream them users will see ���� instead of, say, 🔥. 

This fixes that behavior for MLC and vLLM. Note that MLC was actually broken (returning �), vLLM was returning proper emoji but would first yield three empty strings. 