### PR TITLE
reduce max-conn-per-host

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -117,7 +117,7 @@ async def download_files_with_pget(
     remote_path: str, path: str, files: list[str]
 ) -> None:
     download_jobs = "\n".join(f"{remote_path}/{f} {path}/{f}" for f in files)
-    args = ["pget", "multifile", "-", "-f", "--max-conn-per-host", "100"]
+    args = ["pget", "multifile", "-", "-f", "--max-conn-per-host", "50"]
     process = await asyncio.create_subprocess_exec(*args, stdin=-1, close_fds=True)
     # Wait for the subprocess to finish
     await process.communicate(download_jobs.encode())


### PR DESCRIPTION
Our storagecache pods can't cope with many clients all spinning up 100 connections each to them.  We set rate limits, both on a per-client basis and on an overall-open-connections basis.

This reduces max-conn-per-host to a more managable number.